### PR TITLE
DELETE /api/v1/events/:id

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -34,6 +34,15 @@ class Api::V1::EventsController < ApplicationController
     end
   end
 
+  def destroy
+    if Event.exists?(event_params[:id])
+      event = Event.find(event_params[:id])
+      event.destroy
+    else
+      render json: { errors: "invalid id or poorly formatted request"}, status: 404
+    end
+  end
+
 private
 
   def event_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/events/:id', to: 'events#show'
       post '/events', to: 'events#create'
       patch '/events/:id', to: 'events#update'
+      delete '/events/:id', to: 'events#destroy'
     end
   end
 end

--- a/spec/requests/api/v1/events/get_event_spec.rb
+++ b/spec/requests/api/v1/events/get_event_spec.rb
@@ -95,4 +95,13 @@ describe "event api" do
     expect(results[:errors]).to eq('invalid id or poorly formatted request')
   end
 
+  it "user can delete event", :vcr do
+    event = create(:event, name: 'testing event', details: 'this is a test', id: 7)
+
+    headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+
+    delete "/api/v1/events/7" 
+
+    expect(response.status).to eq(204)
+  end
 end

--- a/spec/requests/api/v1/events/get_event_spec.rb
+++ b/spec/requests/api/v1/events/get_event_spec.rb
@@ -100,8 +100,22 @@ describe "event api" do
 
     headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
 
-    delete "/api/v1/events/7" 
+    delete "/api/v1/events/7"
 
     expect(response.status).to eq(204)
+  end
+
+  it "invalid id for deleting event", :vcr do
+    event = create(:event, name: 'testing event', details: 'this is a test', id: 7)
+
+    headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+
+    delete "/api/v1/events/8"
+
+    expect(response.status).to eq(404)
+
+    results = JSON.parse(response.body, symbolize_names: true)
+
+    expect(results[:errors]).to eq('invalid id or poorly formatted request')
   end
 end


### PR DESCRIPTION
This PR does the following:

- Adds endpoint /api/v1/events/:id for deleting event
- Creates destroy action in event controller
- Route is fully tested, both happy and sad paths